### PR TITLE
Introduce option to use SBT ModuleId as GAV

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ dependencyCheckSkipOptionalScope | Skips analysis for artifacts with Optional Sc
 dependencyCheckSuppressionFile | The file path to the XML suppression file - used to suppress false positives. See [Suppressing False Positives](https://jeremylong.github.io/DependencyCheck/general/suppression.html) for the file syntax. |
 dependencyCheckHintsFile | The file path to the XML hints file - used to resolve [false negatives](https://jeremylong.github.io/DependencyCheck/general/hints.html). |
 dependencyCheckEnableExperimental | Enable the experimental analyzers. If not enabled the experimental analyzers (see below) will not be loaded or used. | false
+dependencyCheckUseSbtModuleIdAsGav | Use the SBT ModuleId as GAV identifier. Ensures GAV is available even if Maven Central isn't. | false
 
 #### Analyzer Configuration
 The following properties are used to configure the various file type analyzers. These properties can be used to turn off specific analyzers if it is not needed. Note, that specific analyzers will automatically disable themselves if no file types that they support are detected - so specifically disabling them may not be needed.

--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckKeys.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckKeys.scala
@@ -55,6 +55,7 @@ trait DependencyCheckKeys {
 	lazy val dependencyCheckDatabaseUser = settingKey[Option[String]]("The username used when connecting to the database. ")
 	lazy val dependencyCheckDatabasePassword = settingKey[Option[String]]("The password used when connecting to the database. ")
 	lazy val dependencyCheckMetaFileName = settingKey[Option[String]]("CURRENTLY NOT USED. Sets the name of the file to use for storing the metadata about the project. ")
+	lazy val dependencyCheckUseSbtModuleIdAsGav = settingKey[Option[Boolean]]("Uses the SBT ModuleId as GAV (reduces dependency on Maven Central for resolving)")
 
 	// TaskKeys
 	lazy val dependencyCheck = TaskKey[Unit]("dependencyCheck", "Runs dependency-check against the project and generates a report.")


### PR DESCRIPTION
SBT resolves it's dependencies already from maven (or a similar repository). This information can be used as GAV info for dependency check.

This reduces the dependency on Maven Central search (Central Analyzer), which is not stable as the server regularly returns a HTTP 500, causing false positives. 