### PR TITLE
Bumped dependency-check-core version to 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ dependencyCheckBundleAuditEnabled | Sets whether or not the Ruby Bundle Audit An
 dependencyCheckPathToBundleAudit| The path to bundle audit. |
 dependencyCheckAssemblyAnalyzerEnabled | Sets whether or not the .NET Assembly Analyzer should be used. | true
 dependencyCheckPathToMono | The path to Mono for .NET assembly analysis on non-windows systems. |
+dependencyCheckCpeStartsWIth | The starting String to identify the CPEs that are qualified to be imported. | 
 
 #### Advanced Configuration
 The following properties can be configured in the plugin. However, they are less frequently changed. One exception may be the cvedUrl properties, which can be used to host a mirror of the NVD within an enterprise environment.

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ sbtPlugin := true
 
 libraryDependencies ++= Seq(
 	"commons-collections" % "commons-collections" % "3.2.2",
-	"org.owasp" % "dependency-check-core" % "3.1.0"
+	"org.owasp" % "dependency-check-core" % "3.1.1"
 )
 libraryDependencies += {
 	appConfiguration.value.provider.id.version match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,6 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"
 libraryDependencies ++= Seq(
   "commons-collections" % "commons-collections" % "3.2.2",
-  "org.owasp" % "dependency-check-core" % "3.1.0",
+  "org.owasp" % "dependency-check-core" % "3.1.1",
   "org.slf4j" % "slf4j-simple" % "1.7.25"
 )

--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckKeys.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckKeys.scala
@@ -18,6 +18,7 @@ trait DependencyCheckKeys {
 	lazy val dependencyCheckSkipOptionalScope = settingKey[Boolean]("Skips analysis for artifacts with Optional Scope ")
 	lazy val dependencyCheckSuppressionFile = settingKey[Option[File]]("The file path to the XML suppression file - used to suppress false positives. If you want to add multiple files use dependencyCheckSuppressionFiles instead.")
 	lazy val dependencyCheckSuppressionFiles = settingKey[Seq[File]]("The sequence of file paths to the XML suppression files - used to suppress false positives")
+	lazy val dependencyCheckCpeStartsWith = settingKey[Option[String]]("The starting String to identify the CPEs that are qualified to be imported.")
 	lazy val dependencyCheckHintsFile = settingKey[Option[File]]("The file path to the XML hints file - used to resolve false negatives.")
 	lazy val dependencyCheckEnableExperimental = settingKey[Option[Boolean]]("Enable the experimental analyzers. If not enabled the experimental analyzers (see below) will not be loaded or used. ")
 	// Analyzer configuration

--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckListSettingsTask.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckListSettingsTask.scala
@@ -68,6 +68,7 @@ object DependencyCheckListSettingsTask {
     logFileSetting(ANALYZER_BUNDLE_AUDIT_PATH, "dependencyCheckPathToBundleAudit", log)
     logBooleanSetting(ANALYZER_ASSEMBLY_ENABLED, "dependencyCheckAssemblyAnalyzerEnabled", log)
     logFileSetting(ANALYZER_ASSEMBLY_MONO_PATH, "dependencyCheckPathToMono", log)
+    logStringSetting(CVE_CPE_STARTS_WITH_FILTER, "dependencyCheckCpeStartsWith", log)
     // Advanced Configuration
     logUrlSetting(CVE_MODIFIED_12_URL, "dependencyCheckCveUrl12Modified", log)
     logUrlSetting(CVE_MODIFIED_20_URL, "dependencyCheckCveUrl20Modified", log)

--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
@@ -183,6 +183,7 @@ object DependencyCheckPlugin extends sbt.AutoPlugin {
     setStringSetting(DB_CONNECTION_STRING, dependencyCheckConnectionString.value)
     setStringSetting(DB_USER, dependencyCheckDatabaseUser.value)
     setStringSetting(DB_PASSWORD, dependencyCheckDatabasePassword.value)
+    setStringSetting(CVE_CPE_STARTS_WITH_FILTER, dependencyCheckCpeStartsWith.value)
 
     initProxySettings()
 

--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckPlugin.scala
@@ -34,6 +34,7 @@ object DependencyCheckPlugin extends sbt.AutoPlugin {
     dependencyCheckSkipOptionalScope := false,
     dependencyCheckSuppressionFile := None,
     dependencyCheckSuppressionFiles := Seq(),
+    dependencyCheckCpeStartsWith := None,
     dependencyCheckHintsFile := None,
     dependencyCheckEnableExperimental := None,
     dependencyCheckArchiveAnalyzerEnabled := None,


### PR DESCRIPTION
As in Issue #34 i've bumped the version of dependency-check-core. 

I'll update the PR to add cpeStartsWithFilter later - or create another PR for that. What's your preference, @albuch ?