### PR TITLE
#50: Updated dependency-check-core to 3.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ sbtPlugin := true
 
 libraryDependencies ++= Seq(
 	"commons-collections" % "commons-collections" % "3.2.2",
-	"org.owasp" % "dependency-check-core" % "3.3.1"
+	"org.owasp" % "dependency-check-core" % "3.3.2"
 )
 libraryDependencies += {
 	appConfiguration.value.provider.id.version match {


### PR DESCRIPTION
looks like a simple bugfix-release, therefore it seems sufficient to just update the version. 