### PR TITLE
dependency-graph plugin version bumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ matrix:
     jdk: oraclejdk7
   - env: SBT_VERSION="0.13.17"
     jdk: oraclejdk8
-  - env: SBT_VERSION="1.2.3"
+  - env: SBT_VERSION="1.2.4"
     jdk: oraclejdk8
-  - env: SBT_VERSION="1.2.3"
+  - env: SBT_VERSION="1.2.4"
     jdk: openjdk11
 script:
   - sbt "^^ ${SBT_VERSION}" clean test scripted dependencyCheck

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val sbtDependencyCheck = project in file(".")
 organization := "net.vonbuchholtz"
 name := "sbt-dependency-check"
 
-crossSbtVersions := Vector("0.13.17", "1.2.3")
+crossSbtVersions := Vector("0.13.17", "1.2.4")
 sbtPlugin := true
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,8 @@
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
 
 // https://github.com/jrudolph/sbt-dependency-graph
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+
 
 unmanagedSourceDirectories in Compile += baseDirectory.value.getParentFile / "src" / "main" / "scala"
 libraryDependencies ++= Seq(


### PR DESCRIPTION
As stated in [#54](https://github.com/albuch/sbt-dependency-check/issues/54) I've upgraded the dependency-graph plugin. 

I've not yet upgraded `commons-collections` due to the warning.