### PR TITLE
Fix header formatting in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,24 +7,24 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+#### Describe the bug
 A clear and concise description of what the bug is.
 
-** Version of sbt-dependency-check used **
+#### Version of sbt-dependency-check used
 The problem occurs using version X.X.X of the the plugin.
 
-** Log file **
+#### Log file
 When reporting errors, 99% of the time log file output is required. Please post the log file as a [gist](https://gist.github.com/) and provide a link in the new issue.
 
-**To Reproduce**
+#### To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+#### Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Additional context**
+#### Additional context
 Add any other context about the problem here.


### PR DESCRIPTION
## Description of Change

Format part headers as headers, instead of bold text.