### PR TITLE
Update CVE JSON data default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ The following properties can be configured in the plugin. However, they are less
 
 Setting | Description | Default Value
 :-------|:------------|:-------------
-dependencyCheckCveUrlModified | URL for the modified CVE JSON data feed. When mirroring the NVD you must mirror the *.json.gz and the *.meta files. | <https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-modified.json.gz>
-dependencyCheckCveUrlBase | Base URL for each year's CVE JSON data feed, the %d will be replaced with the year. | <https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%d.json.gz>
+dependencyCheckCveUrlModified | URL for the modified CVE JSON data feed. When mirroring the NVD you must mirror the *.json.gz and the *.meta files. | <https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz>
+dependencyCheckCveUrlBase | Base URL for each year's CVE JSON data feed, the %d will be replaced with the year. | <https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz>
 dependencyCheckConnectionTimeout | Sets the URL Connection Timeout used when downloading external data. |
 dependencyCheckDataDirectory | Sets the data directory to hold SQL CVEs contents. This should generally not be changed. | [JAR]\data
 dependencyCheckDatabaseDriverName | The name of the database driver. Example: org.h2.Driver. | org.h2.Driver


### PR DESCRIPTION
## Fixes Issue #
The `https://nvd.nist.gov/feeds/json/cve/1.0/` URLs are no longer supported by the NIST and are no longer mentioned on their page, see https://nvd.nist.gov/vuln/data-feeds
## Description of Change

*Please add a description of the proposed change*

Update the README.md to show the new default values.

## Have test cases been added to cover the new functionality?

*no*