### PR TITLE
Update the underlying DependencyCheck library which fixes the defaults

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import sbt.{Project, _}
+import sbt._
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
 import sbtrelease.ReleaseStateTransformations.setNextVersion
@@ -14,9 +14,7 @@ sbtPlugin := true
 
 libraryDependencies ++= Seq(
 	"commons-collections" % "commons-collections" % "3.2.2",
-	"org.owasp" % "dependency-check-core" % "5.3.0",
-	// FIX CVE-2019-10086 introduced by dependency-check-core:5.3.0
-	"commons-beanutils" % "commons-beanutils" % "1.9.4"
+	"org.owasp" % "dependency-check-core" % "6.0.1"
 )
 libraryDependencies ++= {
 	(sbtBinaryVersion in pluginCrossBuild).value match {


### PR DESCRIPTION
## Fixes Issue #??

Updates the underlying version of DependencyCheck to pick up the new default places for the nvdcve feeds


## Have test cases been added to cover the new functionality?

nope.  the readme update is opened elsewhere, which is why this doesn't change that.