### PR TITLE
Fix dependencyCheckFormat value in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ lazy val commonSettings = Seq(
   version := "0.1.0",
   scalaVersion := "2.10.6",
   // Add your sbt-dependency-check settings
-  dependencyCheckFormat := Some("All")
+  dependencyCheckFormat := "ALL"
 )
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
## Fixes Issue #

Using this sample for multi-project SBT config:

```Scala
lazy val commonSettings = Seq(
  organization := "com.example",
  version := "0.1.0",
  scalaVersion := "2.10.6",
  // Add your sbt-dependency-check settings
  dependencyCheckFormat := Some("All")
)
```
I got this error:
```
ERROR error: type mismatch;
ERROR found   : Some[String]
ERROR required: String
ERROR dependencyCheckFormat := Some("All")
ERROR                              ^
ERROR sbt.compiler.EvalException: Type error in expression
```

## Description of Change

Replaced `dependencyCheckFormat` value `Some("All")` in the example code with "ALL" to fix SBT error. 