### PR TITLE
Set ANALYZER_YARN_AUDIT_ENABLED parameter using the correct key

### DIFF
--- a/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckListSettingsTask.scala
+++ b/src/main/scala/net/vonbuchholtz/sbt/dependencycheck/DependencyCheckListSettingsTask.scala
@@ -80,7 +80,7 @@ object DependencyCheckListSettingsTask {
     logBooleanSetting(ANALYZER_NODE_AUDIT_SKIPDEV, "dependencyCheckNodeAuditSkipDevDependencies" , log)
     logBooleanSetting(ANALYZER_NODE_AUDIT_USE_CACHE, "dependencyCheckNodeAuditAnalyzerUseCache", log)
     logBooleanSetting(ANALYZER_NPM_CPE_ENABLED, "dependencyCheckNPMCPEAnalyzerEnabled", log)
-    logBooleanSetting(ANALYZER_YARN_AUDIT_ENABLED, "dependencyCheckNodeAuditSkipDevDependencies", log)
+    logBooleanSetting(ANALYZER_YARN_AUDIT_ENABLED, "dependencyCheckYarnAuditAnalyzerEnabled", log)
     logBooleanSetting(ANALYZER_NUSPEC_ENABLED, "dependencyCheckNuspecAnalyzerEnabled", log)
     logBooleanSetting(ANALYZER_NUGETCONF_ENABLED, "dependencyCheckNugetConfAnalyzerEnabled", log)
     logBooleanSetting(ANALYZER_COCOAPODS_ENABLED, "dependencyCheckCocoapodsEnabled", log)


### PR DESCRIPTION
## Fixes Issue #
#163 

## Description of Change
Previously, the settingKey dependencyCheckYarnAuditAnalyzerEnabled is not used anywhere in the code base. Therefore, setting this key to false does not stop the Yarn Audit Analyzer from being run. This change propose to use the settingKey's value to set the ANALYZER_YARN_AUDIT_ENABLED parameter.

## Have test cases been added to cover the new functionality?

*no*