### PR TITLE
Update jackson dependency

### DIFF
--- a/src/sbt-test/sbt-dependency-check/aggregateProject/build.sbt
+++ b/src/sbt-test/sbt-dependency-check/aggregateProject/build.sbt
@@ -32,5 +32,5 @@ lazy val core = project.dependsOn(util)
 lazy val ignore = (project in file("ignore"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind"  % "2.9.9"
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind"  % "2.13.1"
   )

--- a/src/sbt-test/sbt-dependency-check/anyProject/build.sbt
+++ b/src/sbt-test/sbt-dependency-check/anyProject/build.sbt
@@ -20,5 +20,5 @@ lazy val core = (project in file("core"))
 lazy val inScope = (project in file("inScope"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind"  % "2.9.9"
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind"  % "2.13.1"
   )


### PR DESCRIPTION
## Description of Change

sbt-dependency-check currently depends on a very old version of jackson which is actually creating binary compatibility conflicts with other sbt plugin/s (in my case specifically sbt-coveralls see https://github.com/aiven/guardian-for-apache-kafka/pull/130#issuecomment-1059619307 and https://github.com/scoverage/sbt-coveralls/blob/9a01cf6b10dc8caddc6e0c336375963a04918f0d/build.sbt#L43-L44)

This makes it impossible to use sbt-dependency-check with sbt-coveralls

## Have test cases been added to cover the new functionality?

no but irrelevant since its a dependency bump