### PR TITLE
Update log section with relevent note about tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ and add `-Dlog4j2.level=debug` when running a check:
 sbt -Dlog4j2.level=debug dependencyCheck
 ```
 
+Replace `dependencyCheck` with the right [task name](#tasks) that you use for your project.
+
 
 ### Global Plugin Configuration
 If you want to apply some default configuration for all your SBT projects you can add them as Global Settings:


### PR DESCRIPTION
## Fixes Issue # 
Did not raise one. Should I?

## Description of Change

Provide a note at end of "changing log level" section to set `logLevel` for the right task.
It may look like a very obvious thing to just know but as a user I was expecting `logLevel` to change by changing it for `dependencyChek` task when I was actually using `dependencyCheckAnyProject` task, which is wrong obviously, but a clear mention of it in the readme might help other users :)


## Have test cases been added to cover the new functionality? 

no