### PR TITLE
Issue #282 upstream OWASP DependencyCheck bugfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val sbtDependencyCheck = (project in file("."))
 		libraryDependencies ++= Seq(
 			"com.fasterxml.jackson.core" % "jackson-databind" % "2.14.1",
 			"org.yaml" % "snakeyaml" % "1.33",
-			"org.owasp" % "dependency-check-core" % "7.3.0"
+			"org.owasp" % "dependency-check-core" % "7.4.4"
 		),
 		sbtPlugin := true,
 		dependencyUpdatesFilter -= moduleFilter(organization = "org.scala-lang") | moduleFilter(organization = "org.scala-sbt"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "src
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.1",
   "org.yaml" % "snakeyaml" % "1.33",
-  "org.owasp" % "dependency-check-core" % "7.3.0",
+  "org.owasp" % "dependency-check-core" % "7.4.4",
   "org.slf4j" % "slf4j-simple" % "1.7.36"
 )


### PR DESCRIPTION
A bug in OWASP DependencyCheck <7.4.4 causes exceptions when loading certain poorly formed CVE definitions.

see: https://github.com/jeremylong/DependencyCheck/issues/5220

## Fixes Issue #282 

## Description of Change

Update the DependencyCheck version to 7.4.4 which fixes the upstream issue.

## Have test cases been added to cover the new functionality?

no (no new functionality)